### PR TITLE
Preparing for v0.1 Release

### DIFF
--- a/ExtractCaptions.cpp
+++ b/ExtractCaptions.cpp
@@ -43,7 +43,7 @@ CaptionCandidate constructCandidate(TextWord *word, int page, bool lineStart,
     return CaptionCandidate();
 
   const std::regex wordRegex =
-      std::regex("^(Figure|(FIG)|(Fig\\.)||Fig|Table)$");
+      std::regex("^(Figure|FIGURE|FIG\\.?|Fig\\.?)$");
   std::match_results<const char *> wordMatch;
   if (not std::regex_match(word->getText()->getCString(), wordMatch, wordRegex))
     return CaptionCandidate();

--- a/ExtractCaptions.cpp
+++ b/ExtractCaptions.cpp
@@ -48,7 +48,7 @@ CaptionCandidate constructCandidate(TextWord *word, int page, bool lineStart,
   if (not std::regex_match(word->getText()->getCString(), wordMatch, wordRegex))
     return CaptionCandidate();
 
-  const std::regex numberRegex = std::regex("^([0-9]+)(:|\\.)?$");
+  const std::regex numberRegex = std::regex("^([A-Z][.]?)?([0-9]+)(:|\\.)?$");
 
   std::match_results<const char *> numberMatch;
   std::regex_match(word->getNext()->getText()->getCString(), numberMatch,
@@ -58,7 +58,7 @@ CaptionCandidate constructCandidate(TextWord *word, int page, bool lineStart,
   std::string captionNumStr;
   if (not numberMatch.empty()) {
     captionNumStr = numberMatch[0].str();
-    number = std::stoi(numberMatch[1].str());
+    number = std::stoi(numberMatch[2].str());
   } else {
     return CaptionCandidate();
   }

--- a/PDFUtils.cpp
+++ b/PDFUtils.cpp
@@ -336,8 +336,9 @@ void writeText(TextPage *page, BOX *bb, const char *name,
 void saveFiguresImage(std::vector<Figure> &figures, PIX *original,
                       std::string prefix) {
   for (Figure fig : figures) {
-    std::string name = prefix + "-" + getFigureTypeString(fig.type) + "-" +
-                       std::to_string(fig.number) + ".png";
+    std::ostringstream ss;
+    ss << std::setw(3) << std::setfill('0') << std::to_string(fig.number);
+    std::string name = prefix + "-" + ss.str() + ".png";
     if (fig.imageBB != NULL) {
       pixWrite(name.c_str(), pixClipRectangle(original, fig.imageBB, NULL),
                IFF_PNG);
@@ -348,8 +349,9 @@ void saveFiguresImage(std::vector<Figure> &figures, PIX *original,
 void saveFiguresFullColorImage(std::vector<Figure> &figures, PIX *original,
                       std::string prefix, int multidpi) {
   for (Figure fig : figures) {
-    std::string name = prefix + "-" + getFigureTypeString(fig.type) + "-c" +
-                       std::to_string(fig.number) + ".png";
+    std::ostringstream ss;
+    ss << std::setw(3) << std::setfill('0') << std::to_string(fig.number);
+    std::string name = prefix + "-" + ss.str() + ".png";
     if (fig.imageBB != NULL) {
 
       fig.imageBB->x *= multidpi;

--- a/PDFUtils.h
+++ b/PDFUtils.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <fstream>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <memory>
 
 #include <TextOutputDev.h>


### PR DESCRIPTION
* Only extracts figure captions and ignores Tables
* Matches a wider range of figure caption styles, e.g. Fig. A1
* Zero pads figure number in filename, so img001 etc