### PR TITLE
Only extract figures by default, as originally.

### DIFF
--- a/ExtractCaptions.cpp
+++ b/ExtractCaptions.cpp
@@ -62,7 +62,7 @@ CaptionCandidate constructCandidate(const TextWord *word, int page, bool lineSta
   if (word->getNext() == NULL)
     return CaptionCandidate();
 
-  const std::string captionCue = tablesOnly ? "^(Table|TABLE)$" : "^(Figure|FIGURE|FIG\\.?|Fig\\.?|Table|TABLE)$";
+  const std::string captionCue = tablesOnly ? "^(Table|TABLE)$" : "^(Figure|FIGURE|FIG\\.?|Fig\\.?)$";
   const std::regex wordRegex = std::regex(captionCue);
 
   std::match_results<const char *> wordMatch;


### PR DESCRIPTION
If `-t` option is given, only extract tables.
This retains backwards compatibility with existing API code. In future we can provide an option for both figures and tables.